### PR TITLE
Fix to some Recipes

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1776,7 +1776,8 @@
     "input": {
       "Pure Carbon": 100,
       "Pure Oxygen": 50,
-      "Pure Hydrogen": 50
+      "Pure Hydrogen": 50,
+	  "Tier 1 Product Material Schematic": 1
     }
   },
   "Brick": {
@@ -1791,7 +1792,8 @@
     "input": {
       "Pure Silicon": 50,
       "Pure Aluminium": 50,
-      "Pure Oxygen": 50
+      "Pure Oxygen": 50,
+	  "Tier 1 Product Material Schematic": 1
     }
   },
   "Marble": {
@@ -1805,7 +1807,8 @@
     "input": {
       "Pure Calcium": 50,
       "Pure Carbon": 50,
-      "Pure Oxygen": 50
+      "Pure Oxygen": 50,
+      "Tier 2 Product Material Schematic": 1
     }
   },
   "Concrete": {
@@ -1819,7 +1822,8 @@
     "input": {
       "Pure Calcium": 5,
       "Pure Carbon": 37.5,
-      "Pure Silicon": 37.5
+      "Pure Silicon": 37.5,
+      "Tier 2 Product Material Schematic": 1
     }
   },
   "Carbon Fiber": {
@@ -1833,7 +1837,8 @@
     "industry": "3D Printer M",
     "input": {
       "Polycarbonate Plastic": 50,
-      "Pure Carbon": 50
+      "Pure Carbon": 50,
+	  "Tier 1 Product Material Schematic": 1
     }
   },
   "Glass": {
@@ -1847,7 +1852,8 @@
     "industry": "Glass Furnace M",
     "input": {
       "Pure Silicon": 100,
-      "Pure Oxygen": 50
+      "Pure Oxygen": 50,
+	  "Tier 1 Product Material Schematic": 1
     }
   },
   "Advanced Glass": {
@@ -1862,7 +1868,8 @@
       "Pure Sodium": 100,
       "Pure Calcium": 50,
       "Pure Silicon": 50,
-      "Pure Oxygen": 50
+      "Pure Oxygen": 50,
+	  "Tier 2 Product Material Schematic": 1
     }
   },
   "Ag-Li Reinforced Glass": {
@@ -2048,7 +2055,8 @@
     "industry": "Refiner M",
     "input": {
       "Pure Carbon": 50,
-      "Pure Oxygen": 50
+      "Pure Oxygen": 50,
+      "Tier 1 Product Material Schematic Copy": 1
     }
   },
   "Basic Component": {
@@ -20196,7 +20204,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Copper": 600,
-      "Tier 2 Pure Honeycomb Schematic Copy": 1
+      "Tier 2 Pure Honeycomb Schematic Copy": 6
     }
   },
   "Chromium Honeycomb": {
@@ -20209,7 +20217,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Chromium": 600,
-      "Tier 2 Pure Honeycomb Schematic Copy": 1
+      "Tier 2 Pure Honeycomb Schematic Copy": 6
     }
   },
   "Calcium Honeycomb": {
@@ -20222,7 +20230,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Calcium": 600,
-      "Tier 2 Pure Honeycomb Schematic Copy": 1
+      "Tier 2 Pure Honeycomb Schematic Copy": 6
     }
   },
   "Sodium Honeycomb": {
@@ -20235,7 +20243,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Sodium": 600,
-      "Tier 2 Pure Honeycomb Schematic Copy": 1
+      "Tier 2 Pure Honeycomb Schematic Copy": 6
     }
   },
   "Lithium Honeycomb": {
@@ -20248,7 +20256,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Lithium": 200,
-      "Tier 3 Pure Honeycomb Schematic Copy": 1
+      "Tier 3 Pure Honeycomb Schematic Copy": 2
     }
   },
   "Nickel Honeycomb": {
@@ -20261,7 +20269,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Nickel": 200,
-      "Tier 3 Pure Honeycomb Schematic Copy": 1
+      "Tier 3 Pure Honeycomb Schematic Copy": 2
     }
   },
   "Silver Honeycomb": {
@@ -20274,7 +20282,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Silver": 200,
-      "Tier 3 Pure Honeycomb Schematic Copy": 1
+      "Tier 3 Pure Honeycomb Schematic Copy": 2
     }
   },
   "Sulfur Honeycomb": {
@@ -20287,7 +20295,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Pure Sulfur": 200,
-      "Tier 3 Pure Honeycomb Schematic Copy": 1
+      "Tier 3 Pure Honeycomb Schematic Copy": 2
     }
   },
   "Gold Honeycomb": {
@@ -20405,7 +20413,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Polycarbonate Plastic": 1800,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 18
     }
   },
   "Wood Honeycomb": {
@@ -20419,7 +20427,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Wood": 1800,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 18
     }
   },
   "Concrete Honeycomb": {
@@ -20433,7 +20441,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Concrete": 1800,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 18
     }
   },
   "Carbon Fiber Honeycomb": {
@@ -20447,7 +20455,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Carbon Fiber": 1800,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 18
     }
   },
   "Brick Honeycomb": {
@@ -20461,7 +20469,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Brick": 1800,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 18
     }
   },
   "Steel Honeycomb": {
@@ -20475,7 +20483,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Steel": 1800,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 18
     }
   },
   "Silumin Honeycomb": {
@@ -20489,7 +20497,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Silumin": 1800,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 18
     }
   },
   "Marble Honeycomb": {
@@ -20502,7 +20510,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Marble": 600,
-      "Tier 2 Product Honeycomb Schematic Copy": 1
+      "Tier 2 Product Honeycomb Schematic Copy": 6
     }
   },
   "Duralumin Honeycomb": {
@@ -20515,7 +20523,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Duralumin": 600,
-      "Tier 2 Product Honeycomb Schematic Copy": 1
+      "Tier 2 Product Honeycomb Schematic Copy": 6
     }
   },
   "Stainless Steel Honeycomb": {
@@ -20528,7 +20536,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Stainless Steel": 600,
-      "Tier 2 Product Honeycomb Schematic Copy": 1
+      "Tier 2 Product Honeycomb Schematic Copy": 6
     }
   },
   "Luminescent Glass": {
@@ -20542,7 +20550,7 @@
     "input": {
       "Advanced Glass": 600,
       "Uncommon LED": 60,
-      "Tier 1 Product Honeycomb Schematic Copy": 1
+      "Tier 1 Product Honeycomb Schematic Copy": 6
     }
   },
   "Al-Li Honeycomb": {
@@ -20555,7 +20563,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Al-Li Alloy": 200,
-      "Tier 3 Product Honeycomb Schematic Copy": 1
+      "Tier 3 Product Honeycomb Schematic Copy": 2
     }
   },
   "Inconel Honeycomb": {
@@ -20568,7 +20576,7 @@
     "industry": "Honeycomb Refinery M",
     "input": {
       "Inconel": 200,
-      "Tier 3 Product Honeycomb Schematic Copy": 1
+      "Tier 3 Product Honeycomb Schematic Copy": 2
     }
   },
   "Maraging Steel Honeycomb": {


### PR DESCRIPTION
Correct Base Schematic Values for Honeycomb. 1 schematic = 10m3 of honeycomb based off the base craft.. May require further code updates

Updated Missing Schematics from Product Tier items (marble, glass, adv glass, concrete)

Tested with 5/5 of talents for honeycomb (concrete) and 0/0 skills (both have Basic Product Honeycomb Efficiency 4)
3000 -> 300m  = 30 schematics (0/0 but speed bonus)
2250 -> 375m = 30 (5/5 and speed bonus)

So Honeycomb Efficiency will increase schematic cost per run
Refining and Productivity had no effect on the schematic cost at all